### PR TITLE
[Seeding] convert ids from int to string

### DIFF
--- a/database/scripts/seed.ts
+++ b/database/scripts/seed.ts
@@ -48,7 +48,11 @@ const SLIDES_PER_MODULE = Math.floor(SLIDE_COUNT / MODULE_COUNT);
         const questions = await questionCollection.insertMany(mockQuestions());
         const questionIDs = questions.ops.map((x) => x._id);
 
-        await groupCollection.insertMany(mockGroups(questionIDs));
+        const groups = await groupCollection.insertMany(
+            mockGroups(questionIDs),
+        );
+        const groupIDs = groups.ops.map((x) => x._id);
+
         await componentCollection.insertMany(mockComponents());
         await slideCollection.insertMany(mockSlides());
         await moduleCollection.insertMany(mockModules());
@@ -82,18 +86,18 @@ function mockQuestions() {
 
 function mockGroups(questionIDs) {
     const groups = [];
-    // when QUESTIONS_PER_GROUP = 4:
-    // id: 0   questionIDs: [ questionIDs[0], questionIDs[1], questionIDs[2], questionIDs[3] ]
-    // id: 1   questionIDs: [ questionIDs[4], questionIDs[5], questionIDs[6], questionIDs[7] ]
-    // id: 2   questionIDs: [ questionIDs[8], questionIDs[9], questionIDs[10], questionIDs[11] ]
     for (let i = 0; i < GROUP_COUNT; i++) {
+        // when QUESTIONS_PER_GROUP = 4:
+        // id: 0   questionIDs: [ questionIDs[0], questionIDs[1], questionIDs[2], questionIDs[3] ]
+        // id: 1   questionIDs: [ questionIDs[4], questionIDs[5], questionIDs[6], questionIDs[7] ]
+        // id: 2   questionIDs: [ questionIDs[8], questionIDs[9], questionIDs[10], questionIDs[11] ]
         groups.push({
             questionIDs: questionIDs.slice(
                 QUESTIONS_PER_GROUP * i,
                 QUESTIONS_PER_GROUP * (i + 1),
             ),
         });
-
+    }
     return groups;
 }
 

--- a/database/scripts/seed.ts
+++ b/database/scripts/seed.ts
@@ -58,8 +58,12 @@ const SLIDES_PER_MODULE = Math.floor(SLIDE_COUNT / MODULE_COUNT);
         );
         const componentIDs = components.ops.map((x) => x._id);
 
-        await slideCollection.insertMany(mockSlides(componentIDs));
-        await moduleCollection.insertMany(mockModules());
+        const slides = await slideCollection.insertMany(
+            mockSlides(componentIDs),
+        );
+        const slideIDs = slides.ops.map((x) => x._id);
+
+        await moduleCollection.insertMany(mockModules(slideIDs));
         await toolCollection.insertMany(mockTools());
 
         console.log("Successfully completed seeding");
@@ -132,25 +136,17 @@ function mockSlides(componentIDs) {
     return slides;
 }
 
-function mockModules() {
+function mockModules(slideIDs) {
     const statusTypes = ["complete", "published", "draft"];
     const modules = [];
 
     for (let i = 0; i < MODULE_COUNT; i++) {
-        const slideIDs = [];
-        // when SLIDES_PER_MODULE = 5:
-        // id: 0   slideIDs: [ '0', '1', '2', '3', '4' ]
-        // id: 1   slideIDs: [ '5', '6', '7', '8', '9' ]
-        // id: 2   slideIDs: [ '10', '11', '12', '13', '14' ]
-        for (let j = 0; j < SLIDES_PER_MODULE; j++) {
-            slideIDs.push((i * SLIDES_PER_MODULE + j).toString());
-        }
-
         modules.push({
-            _id: i.toString(),
             title: faker.lorem.words(),
-            toolID: i < TOOL_COUNT ? i.toString() : null,
-            slideIDs,
+            slideIDs: slideIDs.slice(
+                SLIDES_PER_MODULE * i,
+                SLIDES_PER_MODULE * (i + 1),
+            ),
             status: statusTypes[i % statusTypes.length],
             editing: i == 2,
         });

--- a/database/scripts/seed.ts
+++ b/database/scripts/seed.ts
@@ -71,7 +71,7 @@ function mockQuestions() {
 
     for (let i = 0; i < QUESTION_COUNT; i++) {
         questions.push({
-            _id: i,
+            _id: i.toString(),
             type: questionTypes[i % questionTypes.length],
             question: faker.lorem.words() + faker.lorem.words() + "?",
             options: mockOptions[i % mockOptions.length],
@@ -87,15 +87,15 @@ function mockGroups() {
     for (let i = 0; i < GROUP_COUNT; i++) {
         const questionIDs = [];
         // when QUESTIONS_PER_GROUP = 4:
-        // id: 0   questionIDs: [ 0, 1, 2, 3 ]
-        // id: 1   questionIDs: [ 4, 5, 6, 7 ]
-        // id: 2   questionIDs: [ 8, 9, 10, 11 ]
+        // id: 0   questionIDs: [ '0', '1', '2', '3' ]
+        // id: 1   questionIDs: [ '4', '5', '6', '7' ]
+        // id: 2   questionIDs: [ '8', '9', '10', '11' ]
         for (let j = 0; j < QUESTIONS_PER_GROUP; j++) {
-            questionIDs.push(i * QUESTIONS_PER_GROUP + j);
+            questionIDs.push((i * QUESTIONS_PER_GROUP + j).toString());
         }
 
         groups.push({
-            _id: i,
+            _id: i.toString(),
             questionIDs,
         });
     }
@@ -108,7 +108,7 @@ function mockComponents() {
 
     for (let i = 0; i < COMPONENT_COUNT; i++) {
         components.push({
-            _id: i,
+            _id: i.toString(),
             type: componentTypes[i % componentTypes.length],
             properties: {},
         });
@@ -126,14 +126,14 @@ function mockSlides() {
         // id: 1   componentIDs: [ 3, 4, 5 ]
         // id: 2   componentIDs: [ 6, 7, 8 ]
         for (let j = 0; j < COMPONENTS_PER_SLIDE; j++) {
-            componentIDs.push(i * COMPONENTS_PER_SLIDE + j);
+            componentIDs.push((i * COMPONENTS_PER_SLIDE + j).toString());
         }
 
         slides.push({
-            _id: i,
+            _id: i.toString(),
             componentIDs,
-            prevID: i > 0 ? i - 1 : null,
-            nextID: i < SLIDE_COUNT - 1 ? i + 1 : null,
+            prevID: i > 0 ? (i - 1).toString() : null,
+            nextID: i < SLIDE_COUNT - 1 ? (i + 1).toString() : null,
         });
     }
     return slides;
@@ -146,17 +146,18 @@ function mockModules() {
     for (let i = 0; i < MODULE_COUNT; i++) {
         const slideIDs = [];
         // when SLIDES_PER_MODULE = 5:
-        // id: 0   slideIDs: [ 0, 1, 2, 3, 4 ]
-        // id: 1   slideIDs: [ 5, 6, 7, 8, 9 ]
-        // id: 2   slideIDs: [ 10, 11, 12, 13, 14 ]
+        // id: 0   slideIDs: [ '0', '1', '2', '3', '4' ]
+        // id: 1   slideIDs: [ '5', '6', '7', '8', '9' ]
+        // id: 2   slideIDs: [ '10', '11', '12', '13', '14' ]
         for (let j = 0; j < SLIDES_PER_MODULE; j++) {
-            slideIDs.push(i * SLIDES_PER_MODULE + j);
+            slideIDs.push((i * SLIDES_PER_MODULE + j).toString());
         }
 
+        console.log(slideIDs);
         modules.push({
-            _id: i,
+            _id: i.toString(),
             title: faker.lorem.words(),
-            toolID: i < TOOL_COUNT ? i : null,
+            toolID: i < TOOL_COUNT ? i.toString() : null,
             slideIDs,
             status: statusTypes[i % statusTypes.length],
             editing: i == 2,
@@ -172,26 +173,26 @@ function mockTools() {
     for (let i = 0; i < TOOL_COUNT; i++) {
         const relatedToolsIDs = [];
         // generate random related tools:
-        // id: 0   slideIDs: [ 3, 1 ]
-        // id: 1   slideIDs: [ 0 ]
+        // id: 0   slideIDs: [ '3', '1' ]
+        // id: 1   slideIDs: [ '0' ]
         // id: 2   slideIDs: []
-        // id: 3   slideIDs: [ 1, 2, 0 ]
+        // id: 3   slideIDs: [ '1', '2', '0' ]
         while (
             relatedToolsIDs.length < Math.floor(Math.random() * TOOL_COUNT) // generate random number of related tools between 0 and (TOOL_COUNT - 1)
         ) {
             const toolID = Math.floor(Math.random() * TOOL_COUNT);
             // prevent a tool from relating to itself and another tool multiple times
             if (toolID != i && relatedToolsIDs.indexOf(toolID) === -1) {
-                relatedToolsIDs.push(toolID);
+                relatedToolsIDs.push(toolID.toString());
             }
         }
 
         modules.push({
-            _id: i,
+            _id: i.toString(),
             title: faker.lorem.words(),
             video: faker.internet.url(),
             description: faker.lorem.sentences(),
-            moduleID: i < MODULE_COUNT ? i : null,
+            moduleID: i < MODULE_COUNT ? i.toString() : null,
             resources: [
                 {
                     title: faker.lorem.words(),
@@ -204,7 +205,7 @@ function mockTools() {
                     url: faker.internet.url(),
                 },
             ],
-            selfCheckGroupID: i < GROUP_COUNT ? i : null,
+            selfCheckGroupID: i < GROUP_COUNT ? i.toString() : null,
             relatedToolsIDs,
             status: statusTypes[i % statusTypes.length],
             editing: i == 1,

--- a/database/scripts/seed.ts
+++ b/database/scripts/seed.ts
@@ -53,8 +53,12 @@ const SLIDES_PER_MODULE = Math.floor(SLIDE_COUNT / MODULE_COUNT);
         );
         const groupIDs = groups.ops.map((x) => x._id);
 
-        await componentCollection.insertMany(mockComponents());
-        await slideCollection.insertMany(mockSlides());
+        const components = await componentCollection.insertMany(
+            mockComponents(),
+        );
+        const componentIDs = components.ops.map((x) => x._id);
+
+        await slideCollection.insertMany(mockSlides(componentIDs));
         await moduleCollection.insertMany(mockModules());
         await toolCollection.insertMany(mockTools());
 
@@ -107,7 +111,6 @@ function mockComponents() {
 
     for (let i = 0; i < COMPONENT_COUNT; i++) {
         components.push({
-            _id: i.toString(),
             type: componentTypes[i % componentTypes.length],
             properties: {},
         });
@@ -115,24 +118,15 @@ function mockComponents() {
     return components;
 }
 
-function mockSlides() {
+function mockSlides(componentIDs) {
     const slides = [];
 
     for (let i = 0; i < SLIDE_COUNT; i++) {
-        const componentIDs = [];
-        // when COMPONENTS_PER_SLIDE = 3:
-        // id: 0   componentIDs: [ 0, 1, 2 ]
-        // id: 1   componentIDs: [ 3, 4, 5 ]
-        // id: 2   componentIDs: [ 6, 7, 8 ]
-        for (let j = 0; j < COMPONENTS_PER_SLIDE; j++) {
-            componentIDs.push((i * COMPONENTS_PER_SLIDE + j).toString());
-        }
-
         slides.push({
-            _id: i.toString(),
-            componentIDs,
-            prevID: i > 0 ? (i - 1).toString() : null,
-            nextID: i < SLIDE_COUNT - 1 ? (i + 1).toString() : null,
+            componentIDs: componentIDs.slice(
+                COMPONENTS_PER_SLIDE * i,
+                COMPONENTS_PER_SLIDE * (i + 1),
+            ),
         });
     }
     return slides;


### PR DESCRIPTION
## Implementation description
* int ids don't work with Next.js' dynamic routes, this PR converts ids to `ObjectId` in the seeding script 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. run the seeding script
2. ensure ids are strings `ObjectId`


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on
For Frontend changes be sure to specify which routes/pages reviewers should check out!
 -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR