### PR TITLE
Use colorScheme and outlineBlack variant in Modal

### DIFF
--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -20,7 +20,7 @@ export interface ModalProps {
     cancelText?: string;
     confirmText?: string;
     alignButtonsRight?: boolean;
-    confirmButtonColor?: string;
+    confirmButtonColorScheme?: string;
 }
 
 // to control modals:
@@ -36,7 +36,7 @@ export const Modal: React.FC<ModalProps> = (props) => {
         cancelText = "Cancel",
         confirmText = "Confirm",
         alignButtonsRight = true,
-        confirmButtonColor = "black",
+        confirmButtonColorScheme,
         ...rest
     } = props;
 
@@ -67,7 +67,14 @@ export const Modal: React.FC<ModalProps> = (props) => {
                             {cancelText}
                         </Button>
                         {!alignButtonsRight && <Spacer />}
-                        <Button bg={confirmButtonColor} onClick={onConfirm}>
+                        {/* variant="solid" to apply colorScheme */}
+                        <Button
+                            variant={
+                                confirmButtonColorScheme ? "solid" : "default"
+                            }
+                            colorScheme={confirmButtonColorScheme}
+                            onClick={onConfirm}
+                        >
                             {confirmText}
                         </Button>
                     </ModalFooter>

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -60,8 +60,7 @@ export const Modal: React.FC<ModalProps> = (props) => {
                     <ModalFooter>
                         <Button
                             mr="8"
-                            variant="outline"
-                            borderColor="black"
+                            variant="outlineBlack"
                             onClick={onCancel}
                         >
                             {cancelText}

--- a/src/definitions/chakra/theme/components/button.ts
+++ b/src/definitions/chakra/theme/components/button.ts
@@ -8,8 +8,13 @@ const Button = {
             _hover: { bg: "gray.700" },
             _active: { bg: "gray.600" },
         },
-        outline: {
-            colorScheme: "black",
+        outlineBlack: {
+            borderColor: "black",
+            borderWidth: "1px",
+            bg: "transparent",
+            _hover: {
+                bg: "gray.100",
+            },
         },
         brand: {
             bg: "brand.green",


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* add and use `outlineBlack` variant for Modal's cancel button
* set Modal's confirm button's variant to `default` or `solid` depending on `confirmButtonColorScheme` prop


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on
For Frontend changes be sure to specify which routes/pages reviewers should check out!
 -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR