### PR TITLE
[Module Builder] Reset Slide

### DIFF
--- a/pages/admin/dashboard/builder.tsx
+++ b/pages/admin/dashboard/builder.tsx
@@ -120,11 +120,13 @@ function reducer(
             };
         }
         case ModuleActionType.RESET_SLIDE: {
-            const currSlide = state.slides[action.index];
-            currSlide[action.index] = DEFAULT_SLIDE;
             return {
                 ...state,
-                slides: { ...state.slides, ...state.slides[action.index] },
+                slides: [
+                    ...state.slides.slice(0, action.index),
+                    DEFAULT_SLIDE,
+                    ...state.slides.slice(action.index + 1)
+                ]
             };
         }
         case ModuleActionType.SET_SLIDE:

--- a/src/pages/module-builder/Toolbar.tsx
+++ b/src/pages/module-builder/Toolbar.tsx
@@ -96,7 +96,7 @@ const Toolbar = ({
                     icon={<IoTrash />}
                     onClick={() => {
                         dispatch({
-                            type: ModuleActionType.RESET_SLIDE,
+                            type: ModuleActionType.REMOVE_SLIDE,
                             index: state.currentSlide,
                         });
                     }}

--- a/src/pages/module-builder/Toolbar.tsx
+++ b/src/pages/module-builder/Toolbar.tsx
@@ -96,7 +96,7 @@ const Toolbar = ({
                     icon={<IoTrash />}
                     onClick={() => {
                         dispatch({
-                            type: ModuleActionType.REMOVE_SLIDE,
+                            type: ModuleActionType.RESET_SLIDE,
                             index: state.currentSlide,
                         });
                     }}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[Module Builder] Reset Slide](https://www.notion.so/uwblueprintexecs/da60bba45b0d434d964125f89ea73d93?v=a3b26293ac3f462eb6d52550a1a091a3&p=a5be509c6dda4441ae0ff445645bc9fd)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Currently, the trash button removes the slide completely. Instead, we want to have the trash button reset the slide.
* Additionally, reducer should not mutate state.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Click trash button and ensure that a slide resets itself rather than deletes itself.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on
For Frontend changes be sure to specify which routes/pages reviewers should check out!
 -->
## What should reviewers focus on?
* Functionality of resetting
* Ensure reducer is written correctly


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR