### PR TITLE
Hide undo redo behind flag

### DIFF
--- a/src/pages/module-builder/Toolbar.tsx
+++ b/src/pages/module-builder/Toolbar.tsx
@@ -24,6 +24,8 @@ import {
 } from "react-icons/io";
 import { IoTrash } from "react-icons/io5";
 
+const UNDO_ENABLED = false;
+
 const Toolbar = ({
     dispatch,
     state,
@@ -119,8 +121,12 @@ const Toolbar = ({
             <Spacer />
             <ButtonGroup variant="ghost">
                 {/* TODO: Add functionality to these buttons */}
-                <IconButton aria-label="undo" icon={<IoIosUndo />} />
-                <IconButton aria-label="redo" icon={<IoIosRedo />} />
+                {UNDO_ENABLED && (
+                    <>
+                        <IconButton aria-label="undo" icon={<IoIosUndo />} />
+                        <IconButton aria-label="redo" icon={<IoIosRedo />} />
+                    </>
+                )}
                 <IconButton
                     aria-label="trash"
                     icon={<IoTrash />}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Remaining Module Builder Bug Fix](https://www.notion.so/uwblueprintexecs/Module-Builder-Resolve-Bugs-107fcdf4aa7b4f2ca2ff17f24eeb6a4a)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Just hid the Undo and Redo buttons behind a flag


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Nothing to test - just a simple change


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on
For Frontend changes be sure to specify which routes/pages reviewers should check out!
 -->
## What should reviewers focus on?
* Check if arrows are gone


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR