### PR TITLE
feat/ adding google analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 MONGODB_URI=mongodb+srv://<user>:<pass>@<>.mongodb.net/<dbname>?retryWrites=true&w=majority
 MONGODB_DB=<dbname>
+NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=<GoogleAnalyticsMeasurementID>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { Fragment } from "react";
 import { AppProps } from "next/app";
+import Script from "next/script";
+import Head from "next/head";
 import { ChakraProvider } from "@chakra-ui/react";
 import { defaultTheme } from "@definitions/chakra/theme";
 import { Page } from "types/Page";
@@ -16,12 +18,32 @@ type AppPropsWithLayout = AppProps & {
 
 function MyApp({ Component, pageProps }: AppPropsWithLayout): JSX.Element {
     const Layout = Component.layout || PublicLayout;
+
     return (
-        <ChakraProvider theme={defaultTheme}>
-            <Layout>
-                <Component {...pageProps} />
-            </Layout>
-        </ChakraProvider>
+        <>
+            {process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID && (
+                <>
+                    <Script
+                        src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID}`}
+                        strategy="afterInteractive"
+                    />
+                    <Script id="google-analytics" strategy="afterInteractive">
+                        {`
+                        window.dataLayer = window.dataLayer || [];
+                        function gtag(){window.dataLayer.push(arguments);}
+                        gtag('js', new Date());
+
+                        gtag('config', '${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID}');
+                        `}
+                    </Script>
+                </>
+            )}
+            <ChakraProvider theme={defaultTheme}>
+                <Layout>
+                    <Component {...pageProps} />
+                </Layout>
+            </ChakraProvider>
+        </>
     );
 }
 


### PR DESCRIPTION
## Notion ticket link
[Google Analytics Integration](https://www.notion.so/uwblueprintexecs/Task-Board-485f846ae00243599dddba2be9bcba82?p=319af36c5b4a49ab94aa3ebc3077dee0)


## Implementation description:
* added a Google Analytics Tracking ID to the .env.local (and .env.example) files
* added code from https://nextjs.org/docs/messages/next-script-for-ga to the app.tsx file and added condition for it to run only if a Google Analytics Tracking ID was found in the .env file


## Steps to test:
1. Create a Google Analytics account at https://analytics.google.com/analytics/web/ using your Blueprint credentials
2. Follow the instructions for creating an App and Property for HeadsUpGuys
3. Go to the Data Streams Tab and choose to create a Web Platform
4. Add in headsupguys.org for the Website URL and Heads Up Guys Website for the Stream Name, then click "Create Stream"
5. Copy the Google Analytics Measurement ID and paste it into your .env.local file
6. Open the app locally
7. Visit the reports tab (appears as a graph icon on the left of the page)
8. Verify that there has been 1 user

Feel free to message me on Slack if you have any issues setting up Google Analytics.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR