### PR TITLE
add protected tool builder page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@ node_modules
 .DS_Store
 storybook-static
 
+#vscode
+.vscode
+
+#amplify
+src/aws-exports.js
+amplify/*
 #amplify-do-not-edit-begin
 amplify/\#current-cloud-backend
 amplify/.config/local-*
@@ -20,7 +26,7 @@ amplify/backend/.temp
 build/
 dist/
 node_modules/
-# aws-exports.js
+aws-exports.js
 awsconfiguration.json
 amplifyconfiguration.json
 amplifyconfiguration.dart
@@ -28,4 +34,5 @@ amplify-build-config.json
 amplify-gradle-config.json
 amplifytools.xcconfig
 .secret-*
+**.sample
 #amplify-do-not-edit-end

--- a/database/models/section.ts
+++ b/database/models/section.ts
@@ -1,5 +1,5 @@
 import { Schema, Types } from "mongoose";
-import { OptionsQuestion, Question } from "pages/admin/dashboard/builder";
+import { OptionsQuestion } from "pages/admin/dashboard/builder";
 enum SectionType {
     MARKDOWN = "markdown",
     MULTIPLECHOICE = "mc",

--- a/pages/admin/dashboard/builder.tsx
+++ b/pages/admin/dashboard/builder.tsx
@@ -18,10 +18,27 @@ import useSWR from "swr";
 import { Page } from "types/Page";
 import { BuilderLayout } from "@components";
 import { min } from "lodash";
+import { isAuthenticated } from "src/utils/auth/authHelpers";
+import { GetServerSideProps } from "next";
 import Document from "src/pages/module-builder/Document";
 import Editor from "src/pages/module-builder/Editor";
 import Header from "src/pages/module-builder/Header";
 import Toolbar from "src/pages/module-builder/Toolbar";
+
+export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
+    if (process.env.NODE_ENV == "production") {
+        const authProps = await isAuthenticated(req, res, "/redirect", true);
+        return {
+            props: {
+                auth: authProps,
+            },
+        };
+    }
+    else {
+        return {
+            props: {},
+        };
+};
 
 export enum ModuleActionType {
     CHANGE_TITLE,

--- a/pages/admin/dashboard/builder.tsx
+++ b/pages/admin/dashboard/builder.tsx
@@ -33,11 +33,11 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
                 auth: authProps,
             },
         };
-    }
-    else {
+    } else {
         return {
             props: {},
         };
+    }
 };
 
 export enum ModuleActionType {

--- a/pages/admin/dashboard/builder.tsx
+++ b/pages/admin/dashboard/builder.tsx
@@ -27,7 +27,7 @@ import Toolbar from "src/pages/module-builder/Toolbar";
 
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
     if (process.env.NODE_ENV == "production") {
-        const authProps = await isAuthenticated(req, res, "/redirect", true);
+        const authProps = await isAuthenticated(req, res, "/redirect", true); // TODO: change redirect to login page (once we have a login page that's deployed)
         return {
             props: {
                 auth: authProps,

--- a/pages/admin/dashboard/modules.tsx
+++ b/pages/admin/dashboard/modules.tsx
@@ -25,11 +25,11 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
                 auth: authProps,
             },
         };
-    }
-    else {
+    } else {
         return {
             props: {},
         };
+    }
 };
 
 const fetcher = async (url) => {

--- a/pages/admin/dashboard/modules.tsx
+++ b/pages/admin/dashboard/modules.tsx
@@ -19,7 +19,7 @@ import { AdminLayout } from "@components";
 
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
     if (process.env.NODE_ENV == "production") {
-        const authProps = await isAuthenticated(req, res, "/redirect", true);
+        const authProps = await isAuthenticated(req, res, "/redirect", true); // TODO: change redirect to login page (once we have a login page that's deployed)
         return {
             props: {
                 auth: authProps,

--- a/pages/admin/dashboard/modules.tsx
+++ b/pages/admin/dashboard/modules.tsx
@@ -11,10 +11,26 @@ import {
 import axios from "axios";
 import useSWR from "swr";
 import Link from "next/link";
-
+import { isAuthenticated } from "src/utils/auth/authHelpers";
+import { GetServerSideProps } from "next";
 import { ModuleCard } from "@components/ModuleCard";
 import { Page } from "types/Page";
 import { AdminLayout } from "@components";
+
+export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
+    if (process.env.NODE_ENV == "production") {
+        const authProps = await isAuthenticated(req, res, "/redirect", true);
+        return {
+            props: {
+                auth: authProps,
+            },
+        };
+    }
+    else {
+        return {
+            props: {},
+        };
+};
 
 const fetcher = async (url) => {
     const response = await axios({

--- a/pages/admin/dashboard/toolBuilder.tsx
+++ b/pages/admin/dashboard/toolBuilder.tsx
@@ -31,11 +31,11 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
                 auth: authProps,
             },
         };
-    }
-    else {
+    } else {
         return {
             props: {},
         };
+    }
 };
 
 //Self Check Questions React functional component

--- a/pages/admin/dashboard/toolBuilder.tsx
+++ b/pages/admin/dashboard/toolBuilder.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from "react";
+import { isAuthenticated } from "src/utils/auth/authHelpers";
+import { GetServerSideProps } from "next";
 import {
     Text,
     Flex,
@@ -21,11 +23,15 @@ import { SelfCheckQuestionCard, ToolHomePage } from "@components";
 import { useRouter } from "next/router";
 import axios from "axios";
 
-export const getServerSideProps = async () => {
+export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
+    const authProps = await isAuthenticated(req, res, "/redirect", true);
     return {
-        props: {}, // will magically be passed to the page component as props
+        props: {
+            auth: authProps,
+        },
     };
 };
+
 //Self Check Questions React functional component
 const ToolBuilder: Page = () => {
     const router = useRouter();

--- a/pages/admin/dashboard/toolBuilder.tsx
+++ b/pages/admin/dashboard/toolBuilder.tsx
@@ -25,7 +25,7 @@ import axios from "axios";
 
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
     if (process.env.NODE_ENV == "production") {
-        const authProps = await isAuthenticated(req, res, "/redirect", true);
+        const authProps = await isAuthenticated(req, res, "/redirect", true); // TODO: change redirect to login page (once we have a login page that's deployed)
         return {
             props: {
                 auth: authProps,

--- a/pages/admin/dashboard/toolBuilder.tsx
+++ b/pages/admin/dashboard/toolBuilder.tsx
@@ -24,12 +24,18 @@ import { useRouter } from "next/router";
 import axios from "axios";
 
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
-    const authProps = await isAuthenticated(req, res, "/redirect", true);
-    return {
-        props: {
-            auth: authProps,
-        },
-    };
+    if (process.env.NODE_ENV == "production") {
+        const authProps = await isAuthenticated(req, res, "/redirect", true);
+        return {
+            props: {
+                auth: authProps,
+            },
+        };
+    }
+    else {
+        return {
+            props: {},
+        };
 };
 
 //Self Check Questions React functional component

--- a/pages/admin/dashboard/tools.tsx
+++ b/pages/admin/dashboard/tools.tsx
@@ -11,8 +11,25 @@ import {
 import { ToolCard, Modal, AdminLayout } from "@components";
 import { Page } from "types/Page";
 import { useRouter } from "next/router";
+import { isAuthenticated } from "src/utils/auth/authHelpers";
+import { GetServerSideProps } from "next";
 import axios from "axios";
 import useSWR from "swr";
+
+export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
+    if (process.env.NODE_ENV == "production") {
+        const authProps = await isAuthenticated(req, res, "/redirect", true);
+        return {
+            props: {
+                auth: authProps,
+            },
+        };
+    } else {
+        return {
+            props: {},
+        };
+    }
+};
 
 const fetcher = async (url) => {
     const response = await axios({

--- a/pages/admin/dashboard/tools.tsx
+++ b/pages/admin/dashboard/tools.tsx
@@ -18,7 +18,7 @@ import useSWR from "swr";
 
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
     if (process.env.NODE_ENV == "production") {
-        const authProps = await isAuthenticated(req, res, "/redirect", true);
+        const authProps = await isAuthenticated(req, res, "/redirect", true); // TODO: change redirect to login page (once we have a login page that's deployed)
         return {
             props: {
                 auth: authProps,

--- a/src/components/moduleSectionSelect/index.tsx
+++ b/src/components/moduleSectionSelect/index.tsx
@@ -6,11 +6,9 @@ import {
     Heading,
     Text,
     Select,
-    Input,
     Button,
     ButtonGroup,
     Flex,
-    Spacer,
 } from "@chakra-ui/react";
 import {
     MarkdownEditor,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[Auth] Auth protect admin pages](https://www.notion.so/uwblueprintexecs/Auth-Auth-protect-admin-pages-592e30ac6f374462a2a5ff9ae37ed8d2)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Going on an admin page will redirect you if you are not logged in as an admin


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Ensure that visiting the tools page at /admin/dashboard/tools is possible without redirection
2. Change "production" to "development" on line 20 of pages/admin/dashboard/tools
3. Ensure that navigating to the tools page triggers a redirection


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on
For Frontend changes be sure to specify which routes/pages reviewers should check out!
 -->
## What should reviewers focus on?
* That the /admin pages are properly redirected if "production" is changed to "development"
"

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] I have run the appropriate linter(s)
