### PR TITLE
Data Fetching for One Tool

### DIFF
--- a/pages/tool.tsx
+++ b/pages/tool.tsx
@@ -1,15 +1,9 @@
 import React from "react";
-import {
-    Text,
-    Spinner,
-    Heading,
-    AspectRatio,
-} from "@chakra-ui/react";
+import { Text, Spinner, Heading, AspectRatio } from "@chakra-ui/react";
 import axios from "axios";
 import useSWR from "swr";
 
 import { useRouter } from "next/router";
-import { useMediaQuery } from "react-responsive";
 
 const fetcher = async (url) => {
     const response = await axios({
@@ -21,10 +15,7 @@ const fetcher = async (url) => {
 
 const Module: React.FC = () => {
     const router = useRouter();
-    const {id} = router.query;
-    const variant = useMediaQuery({ query: `(max-width: 925px)` })
-        ? "mobile"
-        : "desktop";
+    const { id } = router.query;
 
     const fetchURL = id ? `/api/tool/${id}` : null;
     const { data, error } = useSWR(() => fetchURL, fetcher);
@@ -36,18 +27,12 @@ const Module: React.FC = () => {
             <Heading> {data.title} </Heading>
 
             <AspectRatio maxW="100%" maxH={290} ratio={1}>
-                <iframe
-                    title="Toolkit"
-                    src={data.video}
-                    allowFullScreen
-                />
+                <iframe title="Toolkit" src={data.video} allowFullScreen />
             </AspectRatio>
 
             <br />
 
-            <Text textAlign="left">
-                {data.description}
-            </Text>
+            <Text textAlign="left"> {data.description} </Text>
 
             <br />
 
@@ -58,7 +43,7 @@ const Module: React.FC = () => {
                 </div>
             ))}
         </>
-    )
+    );
 };
 
 export default Module;

--- a/pages/tool.tsx
+++ b/pages/tool.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import {
+    Text,
+    Spinner,
+    Heading,
+    AspectRatio,
+} from "@chakra-ui/react";
+import axios from "axios";
+import useSWR from "swr";
+
+import { useRouter } from "next/router";
+import { useMediaQuery } from "react-responsive";
+
+const fetcher = async (url) => {
+    const response = await axios({
+        method: "GET",
+        url,
+    });
+    return response.data;
+};
+
+const Module: React.FC = () => {
+    const router = useRouter();
+    const {id} = router.query;
+    const variant = useMediaQuery({ query: `(max-width: 925px)` })
+        ? "mobile"
+        : "desktop";
+
+    const fetchURL = id ? `/api/tool/${id}` : null;
+    const { data, error } = useSWR(() => fetchURL, fetcher);
+    if (error) return <div>An error has occurred.</div>;
+    if (!data) return <Spinner color="brand.lime" size="xl" />;
+
+    return (
+        <>
+            <Heading> {data.title} </Heading>
+
+            <AspectRatio maxW="100%" maxH={290} ratio={1}>
+                <iframe
+                    title="Toolkit"
+                    src={data.video}
+                    allowFullScreen
+                />
+            </AspectRatio>
+
+            <br />
+
+            <Text textAlign="left">
+                {data.description}
+            </Text>
+
+            <br />
+
+            {(data.relatedResources ?? []).map((resource) => (
+                <div>
+                    <p>{String(resource[0])}</p>
+                    <a href={resource[1]}>{resource[1]}</a>
+                </div>
+            ))}
+        </>
+    )
+};
+
+export default Module;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Tool landing page data fetching](https://uwblueprintexecs.notion.site/Tool-Landing-Page-Tool-landing-page-data-fetching-13dfb545c1774cd6ad02a2a0b62c15f9)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
This ticket fetches the tool information for a specific tool using the `/api/tool/{id}` api call. It grabs all the information for the tool and displays it on the page with minimal design. 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a tool
2. Copy the tool id and paste it into this route: `locahost:3000/tool?id=<INSERT TOOL ID>`


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on
For Frontend changes be sure to specify which routes/pages reviewers should check out!
 -->
## What should reviewers focus on?
* Ensure all the necessary information is being displayed


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR