### PR TITLE
[Module] Display Tool Titles on Modules Page

### DIFF
--- a/database/models/module.ts
+++ b/database/models/module.ts
@@ -28,6 +28,7 @@ const ModuleSchema = new Schema<ModuleInterface>(
         toolID: {
             type: Schema.Types.ObjectId,
             default: null,
+            ref: "Tool",
         },
         slides: {
             type: [{ type: Schema.Types.ObjectId, ref: "Slide" }],

--- a/pages/admin/dashboard/modules.tsx
+++ b/pages/admin/dashboard/modules.tsx
@@ -81,7 +81,7 @@ const Modules: React.FC = () => {
 
     const { mutate } = useSWRConfig();
     const { data, error } = useSWR(
-        "/api/module/getAll?getToolTitles=1",
+        "/api/module/getAll?getToolTitles=true",
         fetcher,
     );
     if (error) return <div>An error has occurred.</div>;

--- a/pages/admin/dashboard/modules.tsx
+++ b/pages/admin/dashboard/modules.tsx
@@ -80,7 +80,10 @@ const Modules: React.FC = () => {
             : `Are you sure you want to delete the ${selectedModule} module? This will unpublish the ${selectedModuleTool} tool and the ${selectedModule} module and cannot be undone.`;
 
     const { mutate } = useSWRConfig();
-    const { data, error } = useSWR("/api/module/getAll", fetcher);
+    const { data, error } = useSWR(
+        "/api/module/getAll?getToolTitles=1",
+        fetcher,
+    );
     if (error) return <div>An error has occurred.</div>;
     if (!data) return <Spinner color="brand.lime" size="xl" />;
 
@@ -123,7 +126,7 @@ const Modules: React.FC = () => {
                         key={_id}
                         moduleId={_id}
                         title={title}
-                        tool={toolID}
+                        tool={toolID ? toolID.title : toolID}
                         lastUpdated={lastUpdated}
                         author={createdBy.join(", ")}
                         onDelete={onDelete}
@@ -136,7 +139,7 @@ const Modules: React.FC = () => {
 
 const ModulesPage: Page = () => {
     return (
-        <Stack spacing={8}>
+        <Stack marginBottom="40px" spacing={8}>
             <ModulesHeader />
             <Modules />
         </Stack>

--- a/pages/api/module/del.ts
+++ b/pages/api/module/del.ts
@@ -9,11 +9,14 @@ const del = async (
     const { id } = req.query;
     const module = await Module.findByIdAndDelete(id);
 
-    if (!module)
-        return res
-            .status(404)
-            .send({ error: "The module with the given ID was not found." });
-    res.status(204).send({});
+    if (module) {
+        res.status(204).end();
+    } else {
+        res.status(404).send({
+            error: "The module with the given ID was not found.",
+        });
+    }
+    return;
 };
 
 export default del;

--- a/pages/api/module/getAll.ts
+++ b/pages/api/module/getAll.ts
@@ -5,11 +5,16 @@ const getAll = async (
     req: NextApiRequest,
     res: NextApiResponse,
 ): Promise<void> => {
-    try {
-        const modules = await Module.find({});
-        res.status(200).json(modules);
-    } catch (err) {
-        res.status(500).json(err);
+    const { getToolTitles } = req.query;
+    if (getToolTitles) {
+        await Module.find({})
+            .populate("toolID", "title")
+            .then((modules) => res.status(200).json(modules))
+            .catch((err) => res.status(500).send(err));
+    } else {
+        await Module.find({})
+            .then((modules) => res.status(200).json(modules))
+            .catch((err) => res.status(500).send(err));
     }
 };
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[Module] Display Tool Titles on Modules Page](https://www.notion.so/uwblueprintexecs/Module-Display-Tool-Titles-on-Modules-Page-905abc3d7a604f5aabe06755d95a2c91)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added `getToolTitles` query param to `api/module/getAll`
* Used populate to join tool titles if `getToolTitles` query param is true
* Displayed tool titles instead of tool ids on modules page
* Resolved sent statusCode warning when deleting modules (unrelated small fix)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. View modules page
2. Observe that tool titles are displayed after `Linked to:` labels (like in the image below)

<img width="1309" alt="Screen Shot 2022-02-06 at 2 19 40 PM" src="https://user-images.githubusercontent.com/49915445/152697700-cf21f753-3d93-4ba1-97dd-bc8511ffc8fe.png">

3. Delete a linked module
4. Observe that the confirmation modal refers to the tool title (like in the image below)

<img width="1308" alt="Screen Shot 2022-02-06 at 2 28 01 PM" src="https://user-images.githubusercontent.com/49915445/152697994-01f84f3d-b92f-4efd-9640-781cef3050b2.png">

5. After deletion observe that the terminal (whichever window you ran `yarn dev` in) does not display the following warning: `A body was attempted to be set with a 204 statusCode for /api/module/del?id=62001c8e6ed8641a8635697d, this is invalid and the body was ignored.`

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on
For Frontend changes be sure to specify which routes/pages reviewers should check out!
 -->
## What should reviewers focus on?
* Does it work
* Does the implementation make sense


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR