### PR TITLE
Deleting a tool or module unlinks for consistency

### DIFF
--- a/pages/api/module/del.ts
+++ b/pages/api/module/del.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { ErrorResponse } from "types/ErrorResponse";
 import { Module } from "../../../database/models/module";
+import { Tool } from "../../../database/models/tool";
 import connectDB from "../utils/mongoose";
 
 const del = async (
@@ -9,6 +10,15 @@ const del = async (
 ): Promise<void> => {
     const { id } = req.query;
     const module = await Module.findByIdAndDelete(id);
+    const tool = await Tool.findById(module.toolID);
+
+    if (tool) {
+        tool.linkedModuleID = "";
+        if (tool.status == "published") {
+            tool.status = "draft";
+        }
+        await tool.save();
+    }
 
     if (!module)
         return res

--- a/pages/api/tool/deleteOne.ts
+++ b/pages/api/tool/deleteOne.ts
@@ -1,7 +1,6 @@
 import { Tool } from "database/models/tool";
 import { Module } from "../../../database/models/module";
 import { NextApiRequest, NextApiResponse } from "next";
-import { ModifierFlags } from "typescript";
 import connectDB from "../utils/mongoose";
 
 const deleteOne = async (

--- a/pages/api/tool/deleteOne.ts
+++ b/pages/api/tool/deleteOne.ts
@@ -1,5 +1,7 @@
 import { Tool } from "database/models/tool";
+import { Module } from "../../../database/models/module";
 import { NextApiRequest, NextApiResponse } from "next";
+import { ModifierFlags } from "typescript";
 import connectDB from "../utils/mongoose";
 
 const deleteOne = async (
@@ -7,10 +9,17 @@ const deleteOne = async (
     res: NextApiResponse,
 ): Promise<void> => {
     const { id } = req.query;
+    const tool = await Tool.findByIdAndDelete(id);
 
     await Tool.findByIdAndDelete(id)
         .then((tool) => res.status(200).json(tool))
         .catch((err) => res.status(500).send(err));
+
+    if (tool.linkedModuleID != "") {
+        const module = await Module.findById(tool.linkedModuleID);
+        module.toolID = null;
+        await module.save();
+    }
 };
 
 export default connectDB(deleteOne);


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[Tool/Module] Deleting a tool or module unlinks for consistency](https://uwblueprintexecs.notion.site/Tool-Module-Deleting-a-tool-or-module-unlinks-for-consistency-00e937568ff448cb9a9655b84cd6035f)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
It first checks if a tool and module are linked with each other and if so, it deletes the linkage between the two if either both the tool or module are requested to be deleted. 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a tool and module 
2. Link them with each other
3. Delete the tool and check to see if module indicates it is still linked with the deleted tool
4. Repeat steps but delete module rather than tool 


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on
For Frontend changes be sure to specify which routes/pages reviewers should check out!
 -->
## What should reviewers focus on?
1. Ensure an unlinked module and tool can be deleted
5. Ensure a linked module and tool can be deleted and upon deletion, the one that is not deleted does not show it is linked with the deleted one


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR